### PR TITLE
Add Conversion Mechanism

### DIFF
--- a/pyacal/__init__.py
+++ b/pyacal/__init__.py
@@ -3,7 +3,7 @@
 import importlib as _importlib
 
 from ._control_systems import ControlSystemOptions
-from ._facilities import FacilityOptions, Facility
+from ._facilities import Facility, FacilityOptions
 from ._simulators import SimulatorOptions
 
 # NOTE: Package-wide variables must be mutable objects in order to not be

--- a/pyacal/_control_systems/_handle_pvs.py
+++ b/pyacal/_control_systems/_handle_pvs.py
@@ -3,14 +3,12 @@
 from .. import _get_connections_dict, _get_control_system
 
 
-def create_pv(devname, propty, auto_monitor=True, connection_timeout=None):
+def create_pv(devname, propty, connection_timeout=None):
     """Create connection with PV.
 
     Args:
         devname (str): Alias for device name defined in Facility.alias_map.
         propty (str): alias for property name defined in Facility.alias_map.
-        auto_monitor (bool, optional): Whether to turn on auto monitor.
-            Defaults to True.
         connection_timeout (int, optional): time to wait for connection before
             raising Timeout error. Defaults to None.
 
@@ -21,7 +19,6 @@ def create_pv(devname, propty, auto_monitor=True, connection_timeout=None):
     args = (
         devname,
         propty,
-        auto_monitor,
         connection_timeout
     )
     conns = _get_connections_dict()

--- a/pyacal/_control_systems/epics/pv.py
+++ b/pyacal/_control_systems/epics/pv.py
@@ -12,7 +12,6 @@ class PV:
         self,
         devname,
         propty,
-        auto_monitor=True,
         connection_timeout=None
     ):
         """."""
@@ -25,25 +24,13 @@ class PV:
         )
 
         self._pvo = _epics.PV(
-            pvname,
-            auto_monitor=auto_monitor,
-            connection_timeout=connection_timeout
+            pvname, connection_timeout=connection_timeout, auto_monitor=False
         )
 
     @property
     def connected(self):
         """."""
         return self._pvo.connected
-
-    @property
-    def auto_monitor(self):
-        """."""
-        return self._pvo.auto_monitor
-
-    @auto_monitor.setter
-    def auto_monitor(self, value):
-        """."""
-        self._pvo.auto_monitor = int(value)
 
     @property
     def value(self):
@@ -69,11 +56,6 @@ class PV:
     def units(self):
         """."""
         return self._pvo.units
-
-    @property
-    def precision(self):
-        """."""
-        return self._pvo.precision
 
     @property
     def lower_limit(self):

--- a/pyacal/_control_systems/simulation/pv.py
+++ b/pyacal/_control_systems/simulation/pv.py
@@ -10,7 +10,6 @@ class PV:
         self,
         devname,
         propty,
-        auto_monitor=True,
         connection_timeout=None
     ):
         """."""
@@ -25,16 +24,6 @@ class PV:
 
     @property
     def connected(self):
-        """."""
-        raise NotImplementedError('Please Implement me.')
-
-    @property
-    def auto_monitor(self):
-        """."""
-        raise NotImplementedError('Please Implement me.')
-
-    @auto_monitor.setter
-    def auto_monitor(self, value):
         """."""
         raise NotImplementedError('Please Implement me.')
 

--- a/pyacal/_control_systems/tango/pv.py
+++ b/pyacal/_control_systems/tango/pv.py
@@ -8,13 +8,7 @@ from ... import _get_facility
 class PV:
     """PV class."""
 
-    def __init__(
-        self,
-        devname,
-        propty,
-        auto_monitor=True,
-        connection_timeout=None
-    ):
+    def __init__(self, devname, propty, connection_timeout=None):
         """."""
         self.devname = devname
         self.propty = propty
@@ -27,16 +21,6 @@ class PV:
 
     @property
     def connected(self):
-        """."""
-        raise NotImplementedError('Please Implement me.')
-
-    @property
-    def auto_monitor(self):
-        """."""
-        raise NotImplementedError('Please Implement me.')
-
-    @auto_monitor.setter
-    def auto_monitor(self, value):
         """."""
         raise NotImplementedError('Please Implement me.')
 

--- a/pyacal/_conversions/__init__.py
+++ b/pyacal/_conversions/__init__.py
@@ -1,3 +1,5 @@
+"""."""
+
 from .pv import PV
 
 del pv

--- a/pyacal/_conversions/converters.py
+++ b/pyacal/_conversions/converters.py
@@ -3,8 +3,7 @@
 import operator as _operator
 
 import numpy as _np
-from scipy.constants import electron_mass as _electron_mass, \
-    electron_volt as _electron_volt, speed_of_light as _speed_of_light
+from scipy.constants import speed_of_light as _speed_of_light
 
 from .. import _get_facility
 from .utils import ConverterTypes
@@ -220,6 +219,7 @@ class CompanionProptyConverter(_BaseConverter):
         else:
             raise ValueError('Operation must be "add", "sub", "mul" or "div".')
 
+        opr_inv = opr_inv.pop()
         self._opr_fwd = 'truediv' if operation == 'div' else operation
         self._opr_inv = 'truediv' if opr_inv == 'div' else opr_inv
 
@@ -245,16 +245,17 @@ class CompanionProptyConverter(_BaseConverter):
 
 
 class MagRigidityConverter(CompanionProptyConverter):
+    """Ultra-relativistic approximation is used here."""
 
-    _CONST = _electron_mass * _speed_of_light / _electron_volt
+    _CONST = _speed_of_light  # c / (E/e)
 
     def __init__(self, devname='', propty='', energy=0, conv_2_ev=1e9):
-        self._const = self._CONST * conv_2_ev
+        self._const = self._CONST / conv_2_ev
         self._energy = energy
         if not energy:
             super().__init__(devname=devname, propty=propty, operation='div')
         else:
-            self._const *= energy
+            self._const /= energy
 
     @staticmethod
     def get_key(devname='', propty='', energy=0, conv_2_ev=1e9):
@@ -268,4 +269,4 @@ class MagRigidityConverter(CompanionProptyConverter):
     def conversion_reverse(self, value):
         if not self._energy:
             value = super().conversion_reverse(value)
-        return value * self._const
+        return value / self._const

--- a/pyacal/_conversions/converters.py
+++ b/pyacal/_conversions/converters.py
@@ -210,7 +210,7 @@ class CompanionProptyConverter(_BaseConverter):
         if _PV_class is None:
             from .pv import PV
             _PV_class = PV
-        self._prpt_pv = _PV_class(devname, propty, auto_monitor=True)
+        self._prpt_pv = _PV_class(devname, propty)
 
         if operation in self._ADD_SUB:
             opr_inv = self._ADD_SUB - {operation, }

--- a/pyacal/_conversions/converters.py
+++ b/pyacal/_conversions/converters.py
@@ -1,0 +1,271 @@
+"""."""
+
+import operator as _operator
+
+import numpy as _np
+from scipy.constants import electron_mass as _electron_mass, \
+    electron_volt as _electron_volt, speed_of_light as _speed_of_light
+
+from .. import _get_facility
+from .utils import ConverterTypes
+
+__CONVERTERS_DICT = {}
+_PV_class = None
+
+
+def create_converter(converter_type, kwargs):
+    if converter_type not in ConverterTypes:
+        raise TypeError(f'Converter type {converter_type} is not allowed.')
+
+    clss = getattr(globals(), converter_type)
+    key = (converter_type, clss.get_key(**kwargs))
+    conv = __CONVERTERS_DICT.get(key)
+    if conv is None:
+        __CONVERTERS_DICT[key] = clss(**kwargs)
+    return __CONVERTERS_DICT[key]
+
+
+def get_converter(key):
+    conv = __CONVERTERS_DICT.get(key)
+    if conv is None:
+        raise KeyError(
+            'Converter not created yet. use `create_converter` first.'
+        )
+    return conv
+
+
+class _BaseConverter:
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_key():
+        return ()
+
+    def conversion_forward(self, value):
+        return value
+
+    def conversion_reverse(self, value):
+        return value
+
+
+class ScaleConverter(_BaseConverter):
+
+    def __init__(self, scale=1.0):
+        super().__init__()
+        if not isinstance(scale, (int, float, _np.int64, _np.float64)):
+            raise TypeError('Scale must be a number.')
+        scale = float(scale)
+        if _np.isnan(scale) or _np.isinf(scale) or scale == 0.0:
+            raise TypeError('Scale must not be inf, nan or 0.')
+        self._scale = float(scale)
+
+    @staticmethod
+    def get_key(scale=1.0):
+        return (scale, )
+
+    def conversion_forward(self, value):
+        return value * self._scale
+
+    def conversion_reverse(self, value):
+        return value / self._scale
+
+
+class OffsetConverter(_BaseConverter):
+
+    def __init__(self, offset=1.0):
+        super().__init__()
+        if not isinstance(offset, (int, float, _np.int64, _np.float64)):
+            raise TypeError('Offset must be a number.')
+        offset = float(offset)
+        if _np.isnan(offset) or _np.isinf(offset):
+            raise TypeError('Offset must not be inf or nan.')
+        self._offset = float(offset)
+
+    @staticmethod
+    def get_key(offset=1.0):
+        return (offset, )
+
+    def conversion_forward(self, value):
+        return value + self._offset
+
+    def conversion_reverse(self, value):
+        return value - self._offset
+
+
+class LookupTableConverter(_BaseConverter):
+
+    def __init__(self, table_name=''):
+        super().__init__()
+
+        facil = _get_facility()
+        table = _np.array(facil.get_lookup_table(table_name))
+
+        if table.dtype not in (_np.float64, _np.int64):
+            raise ValueError('Lookup table must be of dtype int or float.')
+        elif table.ndim != 2 or table.shape[1] != 2:
+            raise ValueError('Lookup table must have shape (N, 2).')
+
+        diff = _np.diff(table, axis=0)
+        diff *= diff[0]
+        if _np.any(diff <= 0.0):
+            raise ValueError(
+                'Lookup table must be strictly monotonic to be invertible.'
+            )
+        self._table = table
+
+    @staticmethod
+    def get_key(table_name=''):
+        return (table_name, )
+
+    def conversion_forward(self, value):
+        val = _np.interp(
+            value,
+            self.table[:, 0],
+            self.table[:, 1],
+            left=_np.nan,
+            right=_np.nan
+        )
+        if _np.isnan(val):
+            raise ValueError(f'Value {value} is out of bounds.')
+        return val
+
+    def conversion_reverse(self, value):
+        val = _np.interp(
+            value,
+            self.table[:, 1],
+            self.table[:, 0],
+            left=_np.nan,
+            right=_np.nan
+        )
+        if _np.isnan(val):
+            raise ValueError(f'Value {value} is out of bounds.')
+        return val
+
+
+class PolynomialConverter(_BaseConverter):
+
+    def __init__(self, coeffs=(0, 1), limits=(0, 1)):
+        super().__init__()
+
+        if not isinstance(limits, (list, tuple, _np.ndarray)):
+            raise TypeError('Limits must be list, tuple or 1d numpy.ndarray.')
+        elif not isinstance(coeffs, (list, tuple, _np.ndarray)):
+            raise TypeError('Coeffs must be list, tuple or 1d numpy.ndarray.')
+
+        pol = _np.polynomial.Polynomial(coeffs, domain=tuple(limits))
+        pol_der = pol.deriv()
+        roots = pol_der.roots()
+        roots = roots[_np.isreal(roots)]
+        if _np.any(roots > limits[0]) and _np.any(roots < limits[1]):
+            raise TypeError(
+                'Polynom must be strictly monotonic to be invertible.'
+            )
+        self._pol = pol
+        self._pol_der = pol_der
+
+        x = _np.linspace(*limits)
+        y = pol(x)
+        if y[-1] < y[0]:
+            y = y[::-1]
+            x = x[::-1]
+        self._table_guess = _np.vstack([y, x]).T
+
+    @staticmethod
+    def get_key(coefs=(0, 1), limits=(0, 1)):
+        return (tuple(coefs), tuple(limits))
+
+    def conversion_forward(self, value):
+        if not self._pol.domain[0] <= value <= self._pol.domain[1]:
+            raise ValueError(f'Value {value} is out of bounds.')
+        return self._pol(value)
+
+    def conversion_reverse(self, value):
+        val = _np.interp(
+            value,
+            self._table_guess[:, 0],
+            self._table_guess[:, 1],
+            left=_np.nan,
+            right=_np.nan
+        )
+        if _np.isnan(val):
+            raise ValueError(f'Value {value} is out of bounds.')
+
+        res = _np.finfo(_np.float64).resolution
+        for _ in range(10):
+            dval = (value - self._pol(val)) / self._pol_der(val)
+            val += dval
+            if _np.isclose(dval, 0, rtol=0, atol=res):
+                break
+        return val
+
+
+class CompanionProptyConverter(_BaseConverter):
+
+    _ADD_SUB = {'add', 'sub'}
+    _MUL_DIV = {'mul', 'div'}
+
+    def __init__(self, devname='', propty='', operation='add'):
+        global _PV_class
+        if _PV_class is None:
+            from .pv import PV
+            _PV_class = PV
+        self._prpt_pv = _PV_class(devname, propty, auto_monitor=True)
+
+        if operation in self._ADD_SUB:
+            opr_inv = self._ADD_SUB - {operation, }
+        elif operation in self._MUL_DIV:
+            opr_inv = self._MUL_DIV - {operation, }
+        else:
+            raise ValueError('Operation must be "add", "sub", "mul" or "div".')
+
+        self._opr_fwd = 'truediv' if operation == 'div' else operation
+        self._opr_inv = 'truediv' if opr_inv == 'div' else opr_inv
+
+    @staticmethod
+    def get_key(devname='', propty='', operation='add'):
+        return (devname, propty, operation)
+
+    def conversion_forward(self, value):
+        val_comp = self._get_companion_property_value()
+        return getattr(_operator, self._opr_fwd)(value, val_comp)
+
+    def conversion_reverse(self, value):
+        val_comp = self._get_companion_property_value()
+        return getattr(_operator, self._opr_inv)(value, val_comp)
+
+    def _get_companion_property_value(self):
+        if not self._prpt_pv.connected:
+            raise ValueError('Companion property not connected.')
+        val_comp = self._prpt_pv.value
+        if val_comp is None:
+            raise ValueError('Companion property value is None.')
+        return val_comp
+
+
+class MagRigidityConverter(CompanionProptyConverter):
+
+    _CONST = _electron_mass * _speed_of_light / _electron_volt
+
+    def __init__(self, devname='', propty='', energy=0, conv_2_ev=1e9):
+        self._const = self._CONST * conv_2_ev
+        self._energy = energy
+        if not energy:
+            super().__init__(devname=devname, propty=propty, operation='div')
+        else:
+            self._const *= energy
+
+    @staticmethod
+    def get_key(devname='', propty='', energy=0, conv_2_ev=1e9):
+        return (devname, propty, energy, conv_2_ev)
+
+    def conversion_forward(self, value):
+        if not self._energy:
+            value = super().conversion_forward(value)
+        return value * self._const
+
+    def conversion_reverse(self, value):
+        if not self._energy:
+            value = super().conversion_reverse(value)
+        return value * self._const

--- a/pyacal/_conversions/pv.py
+++ b/pyacal/_conversions/pv.py
@@ -29,6 +29,11 @@ class PV:
         return conn
 
     @property
+    def pvname(self):
+        """."""
+        return (self.devname, self.propty)
+
+    @property
     def value(self):
         """."""
         return self.get()

--- a/pyacal/_conversions/pv.py
+++ b/pyacal/_conversions/pv.py
@@ -27,18 +27,6 @@ class PV:
         return pvo.connected
 
     @property
-    def auto_monitor(self):
-        """."""
-        pvo = _get_control_system().get_pv(self._key)
-        return pvo.auto_monitor
-
-    @auto_monitor.setter
-    def auto_monitor(self, value):
-        """."""
-        pvo = _get_control_system().get_pv(self._key)
-        pvo.auto_monitor = int(value)
-
-    @property
     def value(self):
         """."""
         return self.get()
@@ -65,12 +53,6 @@ class PV:
         """."""
         pvo = _get_control_system().get_pv(self._key)
         return pvo.units
-
-    @property
-    def precision(self):
-        """."""
-        pvo = _get_control_system().get_pv(self._key)
-        return pvo.precision
 
     @property
     def lower_limit(self):

--- a/pyacal/_conversions/utils.py
+++ b/pyacal/_conversions/utils.py
@@ -4,7 +4,7 @@ ConverterTypes = {
     'ScaleConverter': {'scale', },
     'OffsetConverter': {'offset', },
     'LookupTableConverter': {'table_name', },
-    'PolynomConverter': {'coeffs', 'limits'},
+    'PolynomConverter': {'coeffs', 'limits', 'is_forward'},
     'CompanionProptyConverter': {'devname', 'propty', 'operation'},
     'MagRigidityConverter': {'devname', 'propty', 'conv_2_ev'},
 }

--- a/pyacal/_conversions/utils.py
+++ b/pyacal/_conversions/utils.py
@@ -1,0 +1,19 @@
+"""."""
+
+ConverterTypes = {
+    'ScaleConverter': {'scale', },
+    'OffsetConverter': {'offset', },
+    'LookupTableConverter': {'table_name', },
+    'PolynomConverter': {'coeffs', 'limits'},
+    'CompanionProptyConverter': {'devname', 'propty', 'operation'},
+    'MagRigidityConverter': {'devname', 'propty', 'conv_2_ev'},
+}
+
+
+class ConverterNames:
+    ScaleConverter = 'ScaleConverter'
+    OffsetConverter = 'OffsetConverter'
+    LookupTableConverter = 'LookupTableConverter'
+    PolynomConverter = 'PolynomConverter'
+    CompanionProptyConverter = 'CompanionProptyConverter'
+    MagRigidityConverter = 'MagRigidityConverter'

--- a/pyacal/_facilities/facility.py
+++ b/pyacal/_facilities/facility.py
@@ -10,6 +10,8 @@ class Facility:
 
     class CSDevTypes:
         PowerSupply = 'PowerSupply'
+        MagnetIndividual = 'MagnetIndividual'
+        MagnetFamily = 'MagnetFamily'
         DipoleNormal = 'DipoleNormal'
         DipoleReverse = 'DipoleReverse'
         DipoleSkew = 'DipoleSkew'
@@ -271,3 +273,4 @@ class Facility:
                 f'Wrong keys to define converter in {propty} of {alias}.\n' +
                 f'    {wrong_keys}\nPossible values:\n    {possible}'
             )
+        return conv

--- a/pyacal/_facilities/facility.py
+++ b/pyacal/_facilities/facility.py
@@ -62,6 +62,10 @@ class Facility:
         """
         raise NotImplementedError('Please implement me.')
 
+    def get_accelerator_object(self, acc=None):
+        acc = acc or self.default_accelerator
+        return self.accelerators[acc]
+
     def add_2_alias_map(self, alias, value):
         """."""
         self._check_map_entry(alias, value)

--- a/pyacal/_facilities/facility.py
+++ b/pyacal/_facilities/facility.py
@@ -1,35 +1,34 @@
 """Module to implement class Facility."""
 from copy import deepcopy as _dcopy
 
-from ..utils import get_namedtuple as _get_namedtuple
+_ConverterTypes = None
+_ConverterNames = None
 
 
 class Facility:
     """."""
 
-    _CS_DEVTYPES = (
-        'PowerSupply',
-        'DipoleNormal',
-        'DipoleReverse',
-        'DipoleSkew',
-        'CorrectorHorizontal',
-        'CorrectorVertical',
-        'QuadrupoleNormal',
-        'QuadrupoleSkew',
-        'SextupoleNormal',
-        'SextupoleSkew',
-        'OctupoleNormal',
-        'OctupoleSkew',
-        'DCCT',
-        'BPM',
-        'IDBPM',
-        'PBPM',
-        'RFGenerator',
-        'RFCavity',
-        'TuneMeas',
-        'SOFB',
-    )
-    CSDevTypes = _get_namedtuple('CSDevTypes', _CS_DEVTYPES, _CS_DEVTYPES)
+    class CSDevTypes:
+        PowerSupply = 'PowerSupply'
+        DipoleNormal = 'DipoleNormal'
+        DipoleReverse = 'DipoleReverse'
+        DipoleSkew = 'DipoleSkew'
+        CorrectorHorizontal = 'CorrectorHorizontal'
+        CorrectorVertical = 'CorrectorVertical'
+        QuadrupoleNormal = 'QuadrupoleNormal'
+        QuadrupoleSkew = 'QuadrupoleSkew'
+        SextupoleNormal = 'SextupoleNormal'
+        SextupoleSkew = 'SextupoleSkew'
+        OctupoleNormal = 'OctupoleNormal'
+        OctupoleSkew = 'OctupoleSkew'
+        DCCT = 'DCCT'
+        BPM = 'BPM'
+        IDBPM = 'IDBPM'
+        PBPM = 'PBPM'
+        RFGenerator = 'RFGenerator'
+        RFCavity = 'RFCavity'
+        TuneMeas = 'TuneMeas'
+        SOFB = 'SOFB'
 
     _AMAP_DEF = {
         'cs_devname': str,
@@ -47,6 +46,19 @@ class Facility:
         self._alias_map = {}
         self.accelerators = {}
         self.default_accelerator = ""
+
+    def get_lookup_table(self, table_name):
+        """Given a table name, this method should find and load the file.
+
+        The class pyacal._converters.converters.LookupTableConverter expects
+        the table to be a numpy.ndarray of shape (N, 2) where N is the number
+        of points of the table.
+
+        Returns:
+            table (numpy.ndarray, (N, 2)): Look-up table.
+
+        """
+        raise NotImplementedError('Please implement me.')
 
     def add_2_alias_map(self, alias, value):
         """."""
@@ -144,6 +156,12 @@ class Facility:
 
     # ---------------------- helper methods ---------------------------
     def _check_map_entry(self, alias, value):
+        global _ConverterNames, _ConverterTypes
+        if _ConverterNames is None:
+            from .._conversions.utils import ConverterNames, ConverterTypes
+            _ConverterTypes = ConverterTypes
+            _ConverterNames = ConverterNames
+
         mapdef = self._AMAP_DEF
         if not isinstance(alias, str):
             raise TypeError('Alias name should be of type str.')
@@ -204,10 +222,52 @@ class Facility:
                 f'Name of propty {propty} of {alias} should be of type str.'
             )
 
-        all_keys = {'name', 'conv_sim2cs', 'conv_cs2phys'}
+        all_keys = {'name', 'conv_cs2sim', 'conv_cs2phys'}
         extra_keys = val.keys() - all_keys
         if extra_keys:
             raise KeyError(
                 f"Propty {propty} of {alias} has extra keys. "
                 f"Possible values are {all_keys}"
+            )
+
+        for name in ('conv_cs2sim', 'conv_cs2phys'):
+            if name not in val.keys():
+                val[name] = []
+            elif isinstance(val[name], (float, int)):
+                val[name] = [{
+                    'type': _ConverterNames.ScaleConverter, 'scale': val[name]
+                }, ]
+            elif isinstance(val[name], (list, tuple)):
+                val[name] = list(val[name])
+                for i, conv in enumerate(val[name]):
+                    val[name][i] = self._check_converter(alias, propty, conv)
+            else:
+                raise TypeError(
+                    f'Entry {name} from propty {propty} of {alias} is wrong.'
+                )
+
+    def _check_converter(self, alias, propty, conv):
+        if isinstance(conv, (float, int)):
+            return {'type': _ConverterNames.ScaleConverter, 'scale': conv}
+
+        if not isinstance(conv, dict):
+            raise TypeError(
+                f'Converter entry must be dict in propty {propty} of {alias}.'
+            )
+
+        if 'type' not in conv:
+            raise KeyError(
+                f'Converter entry must have "type" key in {propty} of {alias}.'
+            )
+        elif conv['type'] not in _ConverterTypes:
+            raise ValueError(
+                f'Converter type not allowed in propty {propty} of {alias}.'
+            )
+
+        possible = _ConverterTypes[conv['type']]
+        wrong_keys = conv.keys() - (possible | {'type'})
+        if wrong_keys:
+            raise ValueError(
+                f'Wrong keys to define converter in {propty} of {alias}.\n' +
+                f'    {wrong_keys}\nPossible values:\n    {possible}'
             )

--- a/pyacal/_facilities/sirius/sirius.py
+++ b/pyacal/_facilities/sirius/sirius.py
@@ -9,8 +9,7 @@ from siriuspy.clientweb import implementation
 from ..._conversions.utils import ConverterNames
 from ..facility import Facility
 
-__CSDT = Facility.CSDevTypes
-__CONVT = ConverterNames
+CSDevTypes = Facility.CSDevTypes
 
 
 def define_si(facil: Facility):
@@ -26,7 +25,7 @@ def define_si(facil: Facility):
         alias,
         {
             'cs_devname': devname,
-            'cs_devtype': {__CSDT.DCCT, },
+            'cs_devtype': {CSDevTypes.DCCT, },
             'accelerator': 'SI',
             'sim_info': {'indices': [famdata['DCCT']['index'][0]]},
             'cs_propties': {
@@ -46,7 +45,7 @@ def define_si(facil: Facility):
             alias,
             {
                 'cs_devname': devname,
-                'cs_devtype': {__CSDT.BPM, __CSDT.SOFB},
+                'cs_devtype': {CSDevTypes.BPM, CSDevTypes.SOFB},
                 'accelerator': 'SI',
                 'sim_info': {'indices': [idcs]},
                 'cs_propties': {
@@ -69,11 +68,11 @@ def define_si(facil: Facility):
     # ------------------- Bending Magnets -----------------------
     convs = [
         {
-            'type': __CONVT.LookupTableConverter,
+            'type': ConverterNames.LookupTableConverter,
             'table_name': 'name_of_excitation_table',
         },
         {
-            'type': __CONVT.MagRigidityConverter,
+            'type': ConverterNames.MagRigidityConverter,
             'energy': 3e9,  # in [eV]
         },
     ]
@@ -100,7 +99,9 @@ def define_si(facil: Facility):
             alias,
             {
                 'cs_devname': devname,
-                'cs_devtype': {__CSDT.DipoleNormal, __CSDT.PowerSupply},
+                'cs_devtype': {
+                    CSDevTypes.DipoleNormal, CSDevTypes.PowerSupply
+                },
                 'accelerator': 'SI',
                 'sim_info': {'indices': famdata[typ]['index']},
                 'cs_propties': _dcopy(props),
@@ -110,11 +111,11 @@ def define_si(facil: Facility):
     # ---------------- Quadrupole and Sextupole Families ------------------
     convs = [
         {
-            'type': __CONVT.LookupTableConverter,
+            'type': ConverterNames.LookupTableConverter,
             'table_name': 'name_of_excitation_table',
         },
         {
-            'type': __CONVT.MagRigidityConverter,
+            'type': ConverterNames.MagRigidityConverter,
             'devname': 'Fam-B1B2-1',
             'propty': 'energy_rb',
             'conv_2_ev': 1e9,  # to convert from [GeV] to [eV]
@@ -147,13 +148,13 @@ def define_si(facil: Facility):
     for typ in typs:
         devname = f'SI-Fam:PS-{typ}'
         alias = 'Fam-' + typ
-        name = __CSDT.QuadrupoleNormal if typ.startswith('Q') \
-            else __CSDT.SextupoleNormal
+        name = CSDevTypes.QuadrupoleNormal if typ.startswith('Q') \
+            else CSDevTypes.SextupoleNormal
         facil.add_2_alias_map(
             alias,
             {
                 'cs_devname': devname,
-                'cs_devtype': {name, __CSDT.PowerSupply},
+                'cs_devtype': {name, CSDevTypes.PowerSupply},
                 'accelerator': 'SI',
                 'sim_info': {'indices': famdata[typ]['index']},
                 'cs_propties': _dcopy(props),
@@ -178,8 +179,8 @@ def define_si(facil: Facility):
     }
     typs = ['CH', 'CV']
     typ_names = [
-        __CSDT.CorrectorHorizontal,
-        __CSDT.CorrectorVertical,
+        CSDevTypes.CorrectorHorizontal,
+        CSDevTypes.CorrectorVertical,
     ]
     for typ, name in zip(typs, typ_names):
         for i, idcs in enumerate(famdata[typ]['index']):
@@ -189,7 +190,9 @@ def define_si(facil: Facility):
                 alias,
                 {
                     'cs_devname': devname,
-                    'cs_devtype': {name, __CSDT.PowerSupply, __CSDT.SOFB},
+                    'cs_devtype': {
+                        name, CSDevTypes.PowerSupply, CSDevTypes.SOFB
+                    },
                     'accelerator': 'SI',
                     'sim_info': {'indices': [idcs]},
                     'cs_propties': _dcopy(props),
@@ -205,7 +208,9 @@ def define_si(facil: Facility):
             alias,
             {
                 'cs_devname': devname,
-                'cs_devtype': {__CSDT.QuadrupoleSkew, __CSDT.PowerSupply},
+                'cs_devtype': {
+                    CSDevTypes.QuadrupoleSkew, CSDevTypes.PowerSupply
+                },
                 'accelerator': 'SI',
                 'sim_info': {'indices': [idcs]},
                 'cs_propties': _dcopy(props),
@@ -215,19 +220,19 @@ def define_si(facil: Facility):
     # --------------------- Normal Quadrupoles -------------------
     convs = [
         {
-            'type': __CONVT.LookupTableConverter,
+            'type': ConverterNames.LookupTableConverter,
             'table_name': 'name_of_excitation_table',
         },
         {
-            'type': __CONVT.MagRigidityConverter,
+            'type': ConverterNames.MagRigidityConverter,
             'devname': 'FamB1B2-1',
             'propty': 'energy_rb',
             'conv_2_ev': 1e9,
         },
         {
-            'type': __CONVT.CompanionProptyConverter,
+            'type': ConverterNames.CompanionProptyConverter,
             'devname': 'Fam-QFA',
-            'propty': 'KL-Mon',
+            'propty': 'strength_mon',
             'operation': 'add',
         },
     ]
@@ -255,7 +260,9 @@ def define_si(facil: Facility):
         table_name = ''
         mapp = {
             'cs_devname': devname,
-            'cs_devtype': {__CSDT.QuadrupoleNormal, __CSDT.PowerSupply},
+            'cs_devtype': {
+                CSDevTypes.QuadrupoleNormal, CSDevTypes.PowerSupply
+            },
             'accelerator': 'SI',
             'sim_info': {'indices': [idcs]},
             'cs_propties': _dcopy(props),
@@ -272,7 +279,7 @@ def define_si(facil: Facility):
         "RFGen",
         {
             'cs_devname': 'RF-Gen',
-            'cs_devtype': {__CSDT.RFGenerator, },
+            'cs_devtype': {CSDevTypes.RFGenerator, },
             'accelerator': 'SI',
             'sim_info': {'indices': famdata['SRFCav']['index']},
             'cs_propties': {
@@ -287,7 +294,7 @@ def define_si(facil: Facility):
         "RFCav",
         {
             'cs_devname': 'SR-RF-DLLRF-01',
-            'cs_devtype': {__CSDT.RFCavity, },
+            'cs_devtype': {CSDevTypes.RFCavity, },
             'accelerator': 'SI',
             'sim_info': {'indices': famdata['SRFCav']['index']},
             'cs_propties': {
@@ -306,7 +313,7 @@ def define_si(facil: Facility):
         "Tune",
         {
             'cs_devname': 'SI-Glob:DI-Tune',
-            'cs_devtype': {__CSDT.TuneMeas, },
+            'cs_devtype': {CSDevTypes.TuneMeas, },
             'accelerator': 'SI',
             'sim_info': {'indices': [[]]},
             'cs_propties': {

--- a/pyacal/_facilities/sirius/sirius.py
+++ b/pyacal/_facilities/sirius/sirius.py
@@ -4,6 +4,7 @@ from copy import deepcopy as _dcopy
 
 import numpy as _np
 import pymodels
+from scipy.constants import elementary_charge, speed_of_light
 from siriuspy.clientweb import implementation
 
 from ..._conversions.utils import ConverterNames
@@ -66,15 +67,16 @@ def define_si(facil: Facility):
     # --------- Define magnets (power supplies) ------------
 
     # ------------------- Bending Magnets -----------------------
+    bc_intfield = 0.7503  # [T.m]
+    bc_deflection = bc_intfield / 3e9 * speed_of_light  # [rad]
+    nominal_deflection = 2*_np.pi / 20 - bc_deflection  # B1 + B2 deflection
+    scale_fac = elementary_charge * speed_of_light / nominal_deflection
     convs = [
         {
             'type': ConverterNames.LookupTableConverter,
             'table_name': 'name_of_excitation_table',
         },
-        {
-            'type': ConverterNames.MagRigidityConverter,
-            'energy': 3e9,  # in [eV]
-        },
+        scale_fac,
     ]
     props = {
         'pwrstate_sp': {'name': ':PwrState-Sel'},

--- a/pyacal/_facilities/sirius/sirius.py
+++ b/pyacal/_facilities/sirius/sirius.py
@@ -102,7 +102,9 @@ def define_si(facil: Facility):
             {
                 'cs_devname': devname,
                 'cs_devtype': {
-                    CSDevTypes.DipoleNormal, CSDevTypes.PowerSupply
+                    CSDevTypes.DipoleNormal,
+                    CSDevTypes.MagnetFamily,
+                    CSDevTypes.PowerSupply,
                 },
                 'accelerator': 'SI',
                 'sim_info': {'indices': famdata[typ]['index']},
@@ -130,11 +132,11 @@ def define_si(facil: Facility):
         'current_rb': {
             'name': ':CurrentRef-Mon', 'conv_cs2sim': _dcopy(convs)},
         'current_mon': {'name': ':Current-Mon', 'conv_cs2sim': _dcopy(convs)},
-        'energy_sp': {'name': ':Current-SP', 'conv_cs2phys': _dcopy(convs)},
-        'energy_rb': {
+        'strength_sp': {'name': ':Current-SP', 'conv_cs2phys': _dcopy(convs)},
+        'strength_rb': {
             'name': ':CurrentRef-Mon', 'conv_cs2phys': _dcopy(convs),
         },
-        'energy_mon': {
+        'strength_mon': {
             'name': ':Current-Mon', 'conv_cs2phys': _dcopy(convs)
         },
     }
@@ -156,7 +158,10 @@ def define_si(facil: Facility):
             alias,
             {
                 'cs_devname': devname,
-                'cs_devtype': {name, CSDevTypes.PowerSupply},
+                'cs_devtype': {
+                    name,
+                    CSDevTypes.MagnetFamily,
+                    CSDevTypes.PowerSupply},
                 'accelerator': 'SI',
                 'sim_info': {'indices': famdata[typ]['index']},
                 'cs_propties': _dcopy(props),
@@ -193,7 +198,10 @@ def define_si(facil: Facility):
                 {
                     'cs_devname': devname,
                     'cs_devtype': {
-                        name, CSDevTypes.PowerSupply, CSDevTypes.SOFB
+                        name,
+                        CSDevTypes.MagnetIndividual,
+                        CSDevTypes.PowerSupply,
+                        CSDevTypes.SOFB,
                     },
                     'accelerator': 'SI',
                     'sim_info': {'indices': [idcs]},
@@ -211,7 +219,9 @@ def define_si(facil: Facility):
             {
                 'cs_devname': devname,
                 'cs_devtype': {
-                    CSDevTypes.QuadrupoleSkew, CSDevTypes.PowerSupply
+                    CSDevTypes.QuadrupoleSkew,
+                    CSDevTypes.MagnetIndividual,
+                    CSDevTypes.PowerSupply,
                 },
                 'accelerator': 'SI',
                 'sim_info': {'indices': [idcs]},
@@ -227,14 +237,14 @@ def define_si(facil: Facility):
         },
         {
             'type': ConverterNames.MagRigidityConverter,
-            'devname': 'FamB1B2-1',
+            'devname': 'Fam-B1B2-1',
             'propty': 'energy_rb',
             'conv_2_ev': 1e9,
         },
         {
             'type': ConverterNames.CompanionProptyConverter,
             'devname': 'Fam-QFA',
-            'propty': 'strength_mon',
+            'propty': 'strength_rb',
             'operation': 'add',
         },
     ]
@@ -263,14 +273,20 @@ def define_si(facil: Facility):
         mapp = {
             'cs_devname': devname,
             'cs_devtype': {
-                CSDevTypes.QuadrupoleNormal, CSDevTypes.PowerSupply
+                CSDevTypes.QuadrupoleNormal,
+                CSDevTypes.MagnetIndividual,
+                CSDevTypes.PowerSupply,
             },
             'accelerator': 'SI',
             'sim_info': {'indices': [idcs]},
             'cs_propties': _dcopy(props),
         }
         for prp in mapp['cs_propties'].values():
-            con = prp.get('conv_cs2phys', prp['conv_cs2sim'])
+            con = prp.get('conv_cs2phys')
+            if con is None:
+                con = prp.get('conv_cs2sim')
+            if con is None:
+                continue
             con[0]['table_name'] = table_name
             con[2]['devname'] = 'Fam-' + devname.dev
 
@@ -291,7 +307,7 @@ def define_si(facil: Facility):
         }
     )
 
-    phs_conv = 180/_np.pi
+    phs_conv = 180 / np.pi
     facil.add_2_alias_map(
         "RFCav",
         {

--- a/pyacal/devices/base.py
+++ b/pyacal/devices/base.py
@@ -137,22 +137,12 @@ class Device:
     def __getitem__(self, propty):
         """Return value of property."""
         pvobj = self.pv_object(propty)
-        try:
-            value = pvobj.get(timeout=Device.GET_TIMEOUT)
-        except Exception:
-            # exceptions raised in a Virtual Circuit Disconnect (192)
-            # event. If the PV IOC goes down, for example.
-            print("Could not get value of {}".format(pvobj.pvname))
-            value = None
-        return value
+        return pvobj.get(timeout=Device.GET_TIMEOUT)
 
     def __setitem__(self, propty, value):
         """Set value of property."""
         pvobj = self.pv_object(propty)
-        try:
-            pvobj.value = value
-        except Exception:
-            print("Could not set value of {}".format(pvobj.pvname))
+        pvobj.value = value
 
     # --- private methods ---
     def _create_pv(self, propty):

--- a/pyacal/devices/bpm.py
+++ b/pyacal/devices/bpm.py
@@ -9,17 +9,13 @@ class BPM(Device):
 
     PROPERTIES_DEFAULT = ("posx", "posy")
 
-    def __init__(self, devname, auto_monitor_mon=True):
+    def __init__(self, devname):
         """."""
         facil = _get_facility()
         if not facil.is_alias_in_cs_devtype(devname, facil.CSDevTypes.BPM):
             raise ValueError(f"Device name: {devname} not valid for a BPM.")
 
-        super().__init__(
-            devname,
-            props2init=BPM.PROPERTIES_DEFAULT,
-            auto_monitor_mon=auto_monitor_mon,
-        )
+        super().__init__(devname, props2init=BPM.PROPERTIES_DEFAULT)
 
     @property
     def posx(self):

--- a/pyacal/devices/fambpms.py
+++ b/pyacal/devices/fambpms.py
@@ -17,7 +17,7 @@ class FamBPMs(DeviceSet):
         if bpmnames is None:
             bpmnames = self._get_default_bpmnames()
 
-        bpmdevs = [_BPM(dev, auto_monitor_mon=False) for dev in bpmnames]
+        bpmdevs = [_BPM(dev) for dev in bpmnames]
         super().__init__(bpmdevs)
         self._bpm_names = bpmnames
 

--- a/pyacal/experiments/bba.py
+++ b/pyacal/experiments/bba.py
@@ -334,6 +334,11 @@ class BBA(_BaseClass):
             {devtypes.QuadrupoleNormal, devtypes.QuadrupoleSkew},
             comp='or',
         )
+        quadnames = facil.find_aliases_from_cs_devtype(
+            devtypes.MagnetIndividual,
+            comp='or',
+            aliases=quadnames,
+        )
         quadnames = facil.find_aliases_from_accelerator(
             self.accelerator, aliases=quadnames
         )
@@ -342,12 +347,8 @@ class BBA(_BaseClass):
         bidcs = facil.get_attribute_from_aliases('sim_info.indices', bpmnames)
 
         acc = self.accelerator
-        qpos = _np.array(
-            [simul.get_positions(idx, acc=acc) for idx in qidcs]
-        ).ravel()
-        bpos = _np.array(
-            [simul.get_positions(idx, acc=acc) for idx in bidcs]
-        ).ravel()
+        qpos = _np.array(simul.get_positions(qidcs, acc=acc)).ravel()
+        bpos = _np.array(simul.get_positions(bidcs, acc=acc)).ravel()
         if qpos.size != len(quadnames) or bpos.size != len(bpmnames):
             raise ValueError(
                 "Size of positions does not match size of indices.\n" +


### PR DESCRIPTION
This PR adds the feature of conversion mechanism to pyacal properties.
The conversions should be defined via `conv_cs2phys` or `conv_cs2sim` keywords of the property as a stream of atomic operation applied to the value.
So far I implemented the following atomic conversions:
 -`ScaleConverter`: multiplies the value by a non-zero scalar;
 -`OffsetConverter`: adds a constant to the value;
 -`LookupTableConverter`: consults an interpolation table. the table name should be passed at the alias map definition and the facility object must have a method called `get_lookup_table` that receives a table name and return the correct table.
 -`PolynomConverter`: apply a polynomial to the value (must be invertible within the defined range);
 -`CompanionProptyConverter`: add/sub/mul/div the value by the value of another pyacal property;
 -`MagRigidityConverter`: divide the value by the magnetic rigidity based on a static provided energy or on the energy property calculated by some other pyacal property (generally from a dipole);

With these atomic converters it is very simple to generate very complicated conversions.
So far, all the atomic conversion must be invertible, to allow forward conversions (from control system to physics units), that are generally used to get some value, and reverse conversions, to allow setting values to the variables.

Maybe we could make this more flexible in the future, by allowing not invertible conversions for read-only PVs.